### PR TITLE
fix(scripts/az/deployment/sub/create): Use `main.bicepparam` instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ env/*.sh
 
 # bicep
 # params
-**/*.biceparam
-
+**/*.bicepparam
+**/*.parameters.json
 
 ##############################
 ### VisualStudio.gitignore ### SRC: https://github.com/github/gitignore/blob/main/VisualStudio.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # env files
 env/*.sh
 
+# bicep
+# params
+**/*.biceparam
+
 
 ##############################
 ### VisualStudio.gitignore ### SRC: https://github.com/github/gitignore/blob/main/VisualStudio.gitignore

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [ ] Translate slides into docs?
 - [ ] Move naming conventions to `docs/az/naming.md`?
 - [ ] Remove "Review + Create" Screenshots? it creates yet-another source-of-truth
-  - See Issue #16: https://github.com/percebus/azure-secure-networking-for-devs/issues/16
+  - See Issue: https://github.com/percebus/azure-secure-networking-for-devs/issues/16
 
 ### bicep
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,9 @@
 - [ ] Translate slides into docs?
 - [ ] Move naming conventions to `docs/az/naming.md`?
 - [ ] Remove "Review + Create" Screenshots? it creates yet-another source-of-truth
+  - See Issue #16: https://github.com/percebus/azure-secure-networking-for-devs/issues/16
 
 ### bicep
 
 - [x] ~~Add `bicep` linting/validation~~
+- [ ] Refactor `scripts/az/deployment` to have a a single `bicepparam` file with all parameters

--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,3 @@
 ### bicep
 
 - [x] ~~Add `bicep` linting/validation~~
-- [ ] Refactor `scripts/az/deployment` to have a a single `bicepparam` file with all parameters

--- a/bicep/.gitignore
+++ b/bicep/.gitignore
@@ -1,2 +1,0 @@
-*.bicepparam
-*.parameters.json

--- a/scripts/az/deployment/sub/create.ba.sh
+++ b/scripts/az/deployment/sub/create.ba.sh
@@ -46,13 +46,14 @@ fi
 set -x
 
 file_path=${project_folder}/main.bicep
+params_file_path=${project_folder}/main.bicepparam
 
 # SRC: https://learn.microsoft.com/en-us/cli/azure/deployment/sub?view=azure-cli-latest#az-deployment-sub-create
 az deployment sub ${cmd} \
   --location ${AZURE_DEPLOYMENT_LOCATION} \
   --name ${deployment_name} \
   --template-file ${file_path} \
-  --parameters prefix=$AZURE_RESOURCES_NAME_PREFIX id=$AZURE_RESOURCES_NAME_ID
+  --parameters ${params_file_path}
 
 set +x
 set +e


### PR DESCRIPTION
# Summary

The script currently has now means to inject the environment variables for the jumpbox username + password

# Issue

- https://github.com/percebus/azure-secure-networking-for-devs/issues/51

# Tests

Tested both modules independently :)

![image](https://github.com/user-attachments/assets/cb9dae0b-63d5-45ff-b0a0-3feb8d0e74b5)
